### PR TITLE
Change RbConfig from a class to a module

### DIFF
--- a/webdriver-firefox.gemspec
+++ b/webdriver-firefox.gemspec
@@ -2,7 +2,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 require 'webdriver-firefox/version'
 
-class RbConfig
+module RbConfig
   class << self
     def files
       fnames = `git ls-files -- bin/* lib/*`.split("\n")


### PR DESCRIPTION
RbConfig is a module and not a class (http://www.ruby-doc.org/stdlib-2.0/libdoc/rubygems/rdoc/RbConfig.html) and changing it to a module works with bundle install.
