### PR TITLE
Fix on Selenium 2.46.0+

### DIFF
--- a/lib/webdriver-firefox/launcher.rb
+++ b/lib/webdriver-firefox/launcher.rb
@@ -12,7 +12,7 @@ module Selenium
         def launch
           find_free_port
           create_profile
-          start_silent_and_wait
+          respond_to?(:start_silent_and_wait) and start_silent_and_wait
           start
           connect_until_stable
 


### PR DESCRIPTION
`start_silent_and_wait` method was removed in Selenium commit [9160eaba5a983ae06050078ec0e03b10654a5eb6](https://github.com/SeleniumHQ/selenium/commit/9160eaba5a983ae06050078ec0e03b10654a5eb6).
